### PR TITLE
Rename PG to PostgreSQL

### DIFF
--- a/charts/aiven-kubernetes-operator/crds/crds.yaml
+++ b/charts/aiven-kubernetes-operator/crds/crds.yaml
@@ -1761,7 +1761,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
-  name: pgs.aiven.io
+  name: postgresqls.aiven.io
 spec:
   conversion:
     strategy: Webhook
@@ -1778,10 +1778,10 @@ spec:
       - v1beta1
   group: aiven.io
   names:
-    kind: PG
-    listKind: PGList
-    plural: pgs
-    singular: pg
+    kind: PostgreSQL
+    listKind: PostgreSQLList
+    plural: postgresqls
+    singular: postgresql
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -1800,7 +1800,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: PG is the Schema for the pgs API
+        description: PostgreSQL is the Schema for the postgresql API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -1811,7 +1811,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: PGSpec defines the desired state of PG
+            description: PostgreSQLSpec defines the desired state of postgres instance
             properties:
               authSecretRef:
                 description: Authentication reference to Aiven token in a secret
@@ -1855,7 +1855,23 @@ spec:
                 description: Time of day when maintenance operations should be performed. UTC time in HH:mm:ss format.
                 maxLength: 8
                 type: string
-              pgUserConfig:
+              plan:
+                description: Subscription plan.
+                maxLength: 128
+                type: string
+              project:
+                description: Target project.
+                format: ^[a-zA-Z0-9_-]*$
+                maxLength: 63
+                type: string
+              projectVpcId:
+                description: Identifier of the VPC the service should be in, if any.
+                maxLength: 36
+                type: string
+              terminationProtection:
+                description: Prevent service from being deleted. It is recommended to have this enabled for all services.
+                type: boolean
+              userConfig:
                 description: PostgreSQL specific user configuration options
                 properties:
                   admin_password:
@@ -2139,7 +2155,7 @@ spec:
                         type: integer
                     type: object
                   pg_service_to_fork_from:
-                    description: Name of the PG Service from which to fork (deprecated, use service_to_fork_from). This has effect only when a new service is being created.
+                    description: Name of the PostgreSQL Service from which to fork (deprecated, use service_to_fork_from). This has effect only when a new service is being created.
                     maxLength: 63
                     type: string
                   pg_version:
@@ -2241,22 +2257,6 @@ spec:
                     minimum: 1
                     type: integer
                 type: object
-              plan:
-                description: Subscription plan.
-                maxLength: 128
-                type: string
-              project:
-                description: Target project.
-                format: ^[a-zA-Z0-9_-]*$
-                maxLength: 63
-                type: string
-              projectVpcId:
-                description: Identifier of the VPC the service should be in, if any.
-                maxLength: 36
-                type: string
-              terminationProtection:
-                description: Prevent service from being deleted. It is recommended to have this enabled for all services.
-                type: boolean
             required:
             - authSecretRef
             - project

--- a/charts/aiven-kubernetes-operator/templates/cluster_role.yaml
+++ b/charts/aiven-kubernetes-operator/templates/cluster_role.yaml
@@ -157,7 +157,7 @@ rules:
 - apiGroups:
   - aiven.io
   resources:
-  - pgs
+  - postgresqls
   verbs:
   - create
   - delete
@@ -169,7 +169,7 @@ rules:
 - apiGroups:
   - aiven.io
   resources:
-  - pgs/status
+  - postgresqls/status
   verbs:
   - get
   - patch
@@ -243,6 +243,7 @@ rules:
   - delete
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - aiven.io
@@ -250,6 +251,7 @@ rules:
   - serviceusers/status
   verbs:
   - get
+  - update
 - apiGroups:
   - coordination.k8s.io
   resources:

--- a/charts/aiven-kubernetes-operator/templates/mutating_webhook_configuration.yaml
+++ b/charts/aiven-kubernetes-operator/templates/mutating_webhook_configuration.yaml
@@ -154,7 +154,7 @@ webhooks:
     service:
       name: {{ include "aiven-kubernetes-operator.fullname" . }}-webhook-service
       namespace: {{ include "aiven-kubernetes-operator.namespace" . }}
-      path: /mutate-aiven-io-v1alpha1-pg
+      path: /mutate-aiven-io-v1alpha1-postgresql
   failurePolicy: Fail
   name: mpg.kb.io
   rules:
@@ -166,7 +166,7 @@ webhooks:
     - CREATE
     - UPDATE
     resources:
-    - pgs
+    - postgresqls
   sideEffects: None
 - admissionReviewVersions:
   - v1

--- a/charts/aiven-kubernetes-operator/templates/validating_webhook_configuration.yaml
+++ b/charts/aiven-kubernetes-operator/templates/validating_webhook_configuration.yaml
@@ -159,7 +159,7 @@ webhooks:
     service:
       name: {{ include "aiven-kubernetes-operator.fullname" . }}-webhook-service
       namespace: {{ include "aiven-kubernetes-operator.namespace" . }}
-      path: /validate-aiven-io-v1alpha1-pg
+      path: /validate-aiven-io-v1alpha1-postgresql
   failurePolicy: Fail
   name: vpg.kb.io
   rules:
@@ -172,7 +172,7 @@ webhooks:
     - UPDATE
     - DELETE
     resources:
-    - pgs
+    - postgresqls
   sideEffects: None
 - admissionReviewVersions:
   - v1


### PR DESCRIPTION
PG was renamed to PostgreSQL in the upstream operator. This PR adressses that and also fixes an issue with missing update ACLs for service users.