### PR TITLE
Add webhooks.containerPort value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
++ add `webhooks.containerPort` value
+
 ## aiven-operator-v0.4.0 - 2022-08-04
 * sync with aiven-operator v0.4.0
 

--- a/charts/aiven-operator/templates/deployment.yaml
+++ b/charts/aiven-operator/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
 
 {{- if .Values.webhooks.enabled }}
             - name: webhook
-              containerPort: 9443
+              containerPort: {{ .Values.webhooks.containerPort | default 9443 }}
               protocol: TCP
 {{- end }}
 

--- a/charts/aiven-operator/values.yaml
+++ b/charts/aiven-operator/values.yaml
@@ -7,6 +7,8 @@ fullnameOverride: ""
 webhooks:
   enabled: true
   servicePort: 443
+  # Set 10250 for GKE, default is 9443
+  # containerPort: 9443
 
 # generic deployment configurations
 image:


### PR DESCRIPTION
GKE firewall rules restrict cluster control plane to only initiate TCP connections to nodes and Pods on ports 443 (HTTPS) and 10250 (kubelet).

via https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#add_firewall_rules