### PR TITLE
Feature: improve deployment security and resilience

### DIFF
--- a/charts/aiven-operator/Chart.yaml
+++ b/charts/aiven-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: aiven-operator
 description: A Helm chart to deploy the aiven operator
 type: application
-version: v0.4.0
+version: v0.4.1
 appVersion: v0.4.0
 maintainers:
   - name: mhoffm-aiven

--- a/charts/aiven-operator/templates/cluster_role_binding.yaml
+++ b/charts/aiven-operator/templates/cluster_role_binding.yaml
@@ -11,5 +11,5 @@ roleRef:
   name: {{ include "aiven-operator.fullname" . }}-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: {{ include "aiven-operator.serviceAccountName" . }}
   namespace: {{ include "aiven-operator.namespace" . }}

--- a/charts/aiven-operator/templates/deployment.yaml
+++ b/charts/aiven-operator/templates/deployment.yaml
@@ -6,7 +6,9 @@ metadata:
   labels:
 {{- include "aiven-operator.labels" . | nindent 4 }}
 spec:
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
 {{- include "aiven-operator.selectorLabels" . | nindent 6 }}

--- a/charts/aiven-operator/templates/deployment.yaml
+++ b/charts/aiven-operator/templates/deployment.yaml
@@ -28,8 +28,13 @@ spec:
 {{- toYaml . | nindent 8 }}
 {{- end }}
 
+      serviceAccountName: {{ include "aiven-operator.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:

--- a/charts/aiven-operator/templates/election_role_binding.yaml
+++ b/charts/aiven-operator/templates/election_role_binding.yaml
@@ -11,5 +11,5 @@ roleRef:
   name: {{ include "aiven-operator.fullname" . }}-election-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: {{ include "aiven-operator.serviceAccountName" . }}
   namespace: {{ include "aiven-operator.namespace" . }}

--- a/charts/aiven-operator/templates/hpa.yaml
+++ b/charts/aiven-operator/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "aiven-operator.fullname" . }}
+  labels:
+    {{- include "aiven-operator.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "aiven-operator.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/aiven-operator/templates/serviceaccount.yaml
+++ b/charts/aiven-operator/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "aiven-operator.serviceAccountName" . }}
+  labels:
+    {{- include "aiven-operator.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/aiven-operator/values.yaml
+++ b/charts/aiven-operator/values.yaml
@@ -42,6 +42,13 @@ resources:
 
 podAnnotations: {}
 
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
 nodeSelector: {}
 
 tolerations: []

--- a/charts/aiven-operator/values.yaml
+++ b/charts/aiven-operator/values.yaml
@@ -1,3 +1,7 @@
+# Default values for aiven-operator.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
 replicaCount: 1
 
 nameOverride: ""
@@ -18,6 +22,15 @@ image:
   tag: ""
 
 imagePullSecrets: []
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
 
 resources:
   limits:

--- a/charts/aiven-operator/values.yaml
+++ b/charts/aiven-operator/values.yaml
@@ -42,6 +42,17 @@ resources:
 
 podAnnotations: {}
 
+podSecurityContext: {}
+  # nAsNonRoot: true
+  # runAsUser: 65532
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # allowPrivilegeEscalation: false
+
 autoscaling:
   enabled: false
   minReplicas: 1

--- a/charts/aiven-operator/values.yaml
+++ b/charts/aiven-operator/values.yaml
@@ -43,7 +43,7 @@ resources:
 podAnnotations: {}
 
 podSecurityContext: {}
-  # nAsNonRoot: true
+  # runAsNonRoot: true
   # runAsUser: 65532
 
 securityContext: {}


### PR DESCRIPTION
The aim of this PR is to add some basic functionality to the resilience and security of the chart.

Added in the PR:

- [x] Support for custom service account and its usage for role binding (instead of only supporting the default sa)
- [x] Add HPA support as an alternative to static replicas
- [x] Add support for Pod and Container security context

The main motivation for this PR was due to the container running as root as default, which should not be needed since the base image is built using [a rootless container](https://github.com/aiven/aiven-operator/blob/main/Dockerfile#L22). The extra bits were just easy nice to have's, that complement the chart with no added effort.

The base values were unchanged, to avoid triggering any unneeded changes. 