### PR TITLE
feat: Support extraEnvs in deployment

### DIFF
--- a/charts/aiven-operator/templates/deployment.yaml
+++ b/charts/aiven-operator/templates/deployment.yaml
@@ -53,6 +53,9 @@ spec:
             - name: WATCHED_NAMESPACES
               value: {{ . | uniq | join "," | quote }}
             {{- end }}
+            {{- if .Values.extraEnvs -}}
+            {{- toYaml .Values.extraEnvs | nindent 12 }}
+            {{- end }}
           command:
             - /manager
           args:

--- a/charts/aiven-operator/values.yaml
+++ b/charts/aiven-operator/values.yaml
@@ -10,6 +10,11 @@ metricsBindAddress: ""
 healthProbeBindAddress: ""
 leaderElect: true
 
+extraEnvs: []
+## Set extra envs for the deployment
+# - name: MY_ENV
+#   value: "my-value"
+
 # Default Aiven Token Secret
 # Configure a single Aiven API token that can be used by all resources.
 # This eliminates the need to create token secrets in every namespace.


### PR DESCRIPTION
When running Aiven Operator onprem we need traffic to go through a webproxy, so we need to be able to set HTTPS_PROXY and NO_PROXY. Adding .Values.extraEnvs solves this for us.